### PR TITLE
change CTA to "Download!", link to latest release

### DIFF
--- a/_sass/landing-page.scss
+++ b/_sass/landing-page.scss
@@ -29,7 +29,7 @@
 .cta.button.alt a {
 	margin: 0 auto;
 	display: flex;
-	max-width: 250px;
+	max-width: 150px;
 	justify-content: center;
 	align-items: center;
 	

--- a/index.html
+++ b/index.html
@@ -10,7 +10,12 @@ description: A powerful build planner for Path of Exile
 		<div>
 			<img src="{{ site.baseurl }}/images/pob_overview.png" alt="Screenshot" />
 		</div>
-		<div class="cta button alt"><a href="https://github.com/PathOfBuildingCommunity/PathOfBuilding/releases"><span class="social-icon">{% include social-icon.html icon="GitHub" %}</span> Grab the latest release!</a></div>
+		<div class="cta button alt">
+			<a href="https://github.com/PathOfBuildingCommunity/PathOfBuilding/releases/latest">
+				<span class="social-icon">{% include social-icon.html icon="GitHub" %}</span>
+				Download!
+			</a>
+		</div>
 	</div>
 </section>
 


### PR DESCRIPTION
before:
<img width="485" alt="image" src="https://github.com/PathOfBuildingCommunity/pathofbuildingcommunity.github.io/assets/90059/ccbec63c-0c5e-43f8-896c-986f528e4942">

after:
<img width="485" alt="image" src="https://github.com/PathOfBuildingCommunity/pathofbuildingcommunity.github.io/assets/90059/3d567fc4-d064-4e39-9a5c-799675e3d66f">

also, link to the latest release instead of the releases page

these changes should make it easier for people who aren't used to github releases to get from the homepage to the download they're looking for
(I watched someone go back to google and try the next result because they thought they were in the wrong place)