### PR TITLE
link directly to installer executable

### DIFF
--- a/_sass/landing-page.scss
+++ b/_sass/landing-page.scss
@@ -38,6 +38,11 @@
 	}
 }
 
+.releases {
+	color: inherit;
+	text-decoration: underline;
+}
+
 .bottom-cta {
 	background: linear-gradient(to bottom, $brand-color 0%, $middle-gradient-color 100%);
 	color: #fff;

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -96,7 +96,7 @@ section + section {
 
 
 .cta {
-	margin: 60px 0;
+	margin: 60px 0 1em;
 }
 
 .page h2 {

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ description: A powerful build planner for Path of Exile
 			<img src="{{ site.baseurl }}/images/pob_overview.png" alt="Screenshot" />
 		</div>
 		<div class="cta button alt">
-			<a href="https://github.com/PathOfBuildingCommunity/PathOfBuilding/releases/latest/download/PathOfBulidingCommunity-Setup.exe">
+			<a href="https://github.com/PathOfBuildingCommunity/PathOfBuilding/releases/latest/download/PathOfBuildingCommunity-Setup.exe">
 				<span class="social-icon">{% include social-icon.html icon="GitHub" %}</span>
 				Download!
 			</a>

--- a/index.html
+++ b/index.html
@@ -11,11 +11,14 @@ description: A powerful build planner for Path of Exile
 			<img src="{{ site.baseurl }}/images/pob_overview.png" alt="Screenshot" />
 		</div>
 		<div class="cta button alt">
-			<a href="https://github.com/PathOfBuildingCommunity/PathOfBuilding/releases/latest">
+			<a href="https://github.com/PathOfBuildingCommunity/PathOfBuilding/releases/latest/download/PathOfBulidingCommunity-Setup.exe">
 				<span class="social-icon">{% include social-icon.html icon="GitHub" %}</span>
 				Download!
 			</a>
 		</div>
+		<a href="https://github.com/PathOfBuildingCommunity/PathOfBuilding/releases" class="releases">
+			See all releases
+		</a>
 	</div>
 </section>
 


### PR DESCRIPTION
we'll need to change `PathOfBuilding-Installer/make_release.py` to not output the version number in the artifact name first. otherwise, **this breaks the download link**, so don't merge until that happens

this also adds a second link to the releases page
![image](https://github.com/PathOfBuildingCommunity/pathofbuildingcommunity.github.io/assets/90059/3fb31986-3895-47fa-af2d-c331abd6bb56)